### PR TITLE
Make get_fs_directories non recursive

### DIFF
--- a/admin/include/functions.php
+++ b/admin/include/functions.php
@@ -605,20 +605,24 @@ function get_fs_directories($path, $recursive = true)
 
   if (is_dir($path))
   {
-    if ($contents = opendir($path))
+    $remaining = array($path);
+    while ($path = array_shift($remaining))
     {
-      while (($node = readdir($contents)) !== false)
+      if ($contents = opendir($path))
       {
-        if (is_dir($path.'/'.$node) and !isset($exclude_folders[$node]))
+        while (($node = readdir($contents)) !== false)
         {
-          $dirs[] = $path.'/'.$node;
-          if ($recursive)
+          if (!isset($exclude_folders[$node]) and is_dir($path.'/'.$node))
           {
-            $dirs = array_merge($dirs, get_fs_directories($path.'/'.$node));
+            $dirs[] = $path.'/'.$node;
+            if ($recursive)
+            {
+              array_unshift($remaining[], $path.'/'.$node);
+            }
           }
         }
+        closedir($contents);
       }
-      closedir($contents);
     }
   }
 


### PR DESCRIPTION
This will make get_fs_directories non recursive, thus fixing a potential stack overflow when operating on directories with quite large depth.
It might change a bit the order directories appear in the list though.